### PR TITLE
ファイル保存時の保存メッセージを抑制できるようにしたお

### DIFF
--- a/auto-save-buffers-enhanced.el
+++ b/auto-save-buffers-enhanced.el
@@ -134,6 +134,9 @@ not CVS or Subversion.")
   "*Path of the config file of svk, which is usually located in
 ~/.svk/config.")
 
+(defvar auto-save-buffers-enhanced-quiet-save-p nil
+  "*If non-nil, without 'Wrote <filename>' message.")
+
 (defvar auto-save-buffers-enhanced-save-scratch-buffer-to-file-p nil
   "*If non-nil, *scratch* buffer will be saved into the file same
 as other normal files.")
@@ -224,23 +227,30 @@ the directories under VCS."
                (not (auto-save-buffers-enhanced-regexps-match-p
                      auto-save-buffers-enhanced-exclude-regexps buffer-file-name))
                (file-writable-p buffer-file-name))
-          (save-buffer)
+          (auto-save-buffers-enhanced-saver-buffer)
         (when (and auto-save-buffers-enhanced-save-scratch-buffer-to-file-p
                    (equal buffer (get-buffer "*scratch*"))
                    (buffer-modified-p)
                    (not (string= initial-scratch-message (buffer-string))))
-          (let
-              ((scratch-buffer-string (buffer-string)))
-            (progn
-              (with-temp-buffer
-                (insert scratch-buffer-string)
-                (write-region nil nil
-                              auto-save-buffers-enhanced-file-related-with-scratch-buffer
-                              nil  -1))
-              (set-buffer-modified-p nil))))))))
+          (auto-save-buffers-enhanced-saver-buffer 'scratch))))))
 
 ;;;; Internal Functions
 ;;;; -------------------------------------------------------------------------
+
+(defun auto-save-buffers-enhanced-saver-buffer (&optional scratch-p)
+  (if (or scratch-p
+          auto-save-buffers-enhanced-quiet-save-p)
+      (let
+          ((content (buffer-string))
+           (file-name (if scratch-p
+                          auto-save-buffers-enhanced-file-related-with-scratch-buffer
+                        buffer-file-name)))
+        (progn
+          (with-temp-file file-name
+            (insert content))
+          (set-buffer-modified-p nil)
+          (set-visited-file-modtime (current-time))))
+    (save-buffer)))
 
 (defun auto-save-buffers-enhanced-regexps-match-p (regexps string)
   (catch 'matched


### PR DESCRIPTION
with-temp-file を通してファイルを保存することで 'Wrote <filename>' を出さなくしました。

いちいち with-temp-file に buffer-string の内容渡してるので、おっきなバッファだと遅かったり固まったりするかも。
