### PR TITLE
Improved quiet save buffer

### DIFF
--- a/auto-save-buffers-enhanced.el
+++ b/auto-save-buffers-enhanced.el
@@ -247,11 +247,18 @@ the directories under VCS."
         (insert content))
       (set-buffer-modified-p nil)))
    (auto-save-buffers-enhanced-quiet-save-p
-    (progn
-      (set-visited-file-modtime (current-time))
-      (write-region nil nil buffer-file-name nil -1)
-      (set-buffer-modified-p nil)))
+    (auto-save-buffers-enhanced-quiet-save-buffer))
    (t (save-buffer))))
+
+(defun auto-save-buffers-enhanced-quiet-save-buffer ()
+  (fset 'original-write-region (symbol-function 'write-region))
+  (flet
+      ((write-region (start end filename &optional append visit lockname mustbenew)
+                     (original-write-region start end filename append -1 lockname mustbenew))
+       (message (format-string &rest args) t))
+    (save-buffer)
+    (set-buffer-modified-p nil)
+    (clear-visited-file-modtime)))
 
 (defun auto-save-buffers-enhanced-regexps-match-p (regexps string)
   (catch 'matched


### PR DESCRIPTION
- call (save-buffer) from inside.
  - enable "before-save-hook" and "after-save-hook".
- call (clear-visited-file-modtime) at the end.
  - suppress the message "changed on disk; really edit the buffer?"
