### PR TITLE
Save even after an undo

### DIFF
--- a/auto-save-buffers-enhanced.el
+++ b/auto-save-buffers-enhanced.el
@@ -148,6 +148,10 @@ as other normal files.")
   (expand-file-name "~/.scratch")
   "*File which scratch buffer to be save into.")
 
+(defvar auto-save-buffers-enhanced-handle-undo-function-list
+  '(undo undo-tree-undo undo-tree-redo)
+  "*Change file state to `modified` after these undo functions invocations.")
+
 ;;;; Imprementation Starts from Here...
 ;;;; -------------------------------------------------------------------------
 
@@ -303,6 +307,15 @@ the directories under VCS."
             (cons (concat "^" (regexp-quote checkout-path))
                   auto-save-buffers-enhanced-include-regexps)))
     (cd current-dir)))
+
+(defun auto-save-buffers-enhanced-undo:after (&rest args)
+  "Set the modified flag if needed.  ARGS are not in use on this advice."
+  (when auto-save-buffers-enhanced-activity-flag
+    (set-buffer-modified-p t)))
+
+(mapc #'(lambda (func)
+          (advice-add func :after 'auto-save-buffers-enhanced-undo:after))
+      auto-save-buffers-enhanced-handle-undo-function-list)
 
 (provide 'auto-save-buffers-enhanced)
 


### PR DESCRIPTION
Up to now, even if "undo" method was executed, it was not written to the file. This change will fix it.